### PR TITLE
Feat: Add support for custom file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ j2lint --list
 j2lint <path-to-directory-of-templates> --verbose
 ```
 
+### Running the linter with custom file extensions
+
+```bash
+j2lint <path-to-directory-of-templates> --extensions j2,html,yml
+```
+
 ### Running the linter with logs enabled. Logs saved in jinja2-linter.log in the current directory
 
 ```bash

--- a/j2lint/cli.py
+++ b/j2lint/cli.py
@@ -82,6 +82,13 @@ def create_parser() -> argparse.ArgumentParser:
         help="verbose output for lint issues",
     )
     parser.add_argument(
+        "-e",
+        "--extensions",
+        default="j2,jinja,jinja2",
+        help="comma delimited list of file extensions, default is 'j2,jinja,jinja2'",
+        type=lambda s: [f".{item}" for item in s.split(",")],
+    )
+    parser.add_argument(
         "-d", "--debug", default=False, action="store_true", help="enable debug logs"
     )
     parser.add_argument(
@@ -139,12 +146,11 @@ def sort_issues(issues: list[LinterError]) -> list[LinterError]:
 
 
 def get_linting_issues(
-    file_or_dir_names: list[str], collection: RulesCollection, checked_files: list[str]
+    files: list[str], collection: RulesCollection, checked_files: list[str]
 ) -> tuple[dict[str, list[LinterError]], dict[str, list[LinterError]]]:
     """checking errors and warnings"""
     lint_errors: dict[str, list[LinterError]] = {}
     lint_warnings: dict[str, list[LinterError]] = {}
-    files = get_files(file_or_dir_names)
 
     # Get linting issues
     for file_name in files:
@@ -301,9 +307,9 @@ def run(args: list[str] | None = None) -> int:
         parser.print_help(file=sys.stderr)
         return 1
 
-    lint_errors, lint_warnings = get_linting_issues(
-        file_or_dir_names, collection, checked_files
-    )
+    files = get_files(file_or_dir_names, options.extensions)
+
+    lint_errors, lint_warnings = get_linting_issues(files, collection, checked_files)
 
     if options.json:
         logger.debug("JSON output enabled")

--- a/j2lint/linter/collection.py
+++ b/j2lint/linter/collection.py
@@ -45,9 +45,7 @@ class RulesCollection:
         """
         self.rules.extend(more)
 
-    def run(
-        self, file_dict: dict[str, str]
-    ) -> tuple[list[LinterError], list[LinterError]]:
+    def run(self, file_path: str) -> tuple[list[LinterError], list[LinterError]]:
         """Runs the linting rules for given file
 
         Args:
@@ -62,10 +60,10 @@ class RulesCollection:
         warnings: list[LinterError] = []
 
         try:
-            with open(file_dict["path"], mode="r", encoding="utf-8") as file:
+            with open(file_path, mode="r", encoding="utf-8") as file:
                 text = file.read()
         except IOError as err:
-            logger.warning("Could not open %s - %s", file_dict["path"], err.strerror)
+            logger.warning("Could not open %s - %s", file_path, err.strerror)
             return errors, warnings
 
         for rule in self.rules:
@@ -74,21 +72,19 @@ class RulesCollection:
                     "Ignoring rule %s:%s for file %s",
                     rule.rule_id,
                     rule.short_description,
-                    file_dict["path"],
+                    file_path,
                 )
                 continue
             if is_rule_disabled(text, rule):
-                logger.debug(
-                    "Skipping linting rule %s on file %s", rule, file_dict["path"]
-                )
+                logger.debug("Skipping linting rule %s on file %s", rule, file_path)
                 continue
 
-            logger.debug("Running linting rule %s on file %s", rule, file_dict["path"])
+            logger.debug("Running linting rule %s on file %s", rule, file_path)
             if rule in rule.warn:
-                warnings.extend(rule.checkrule(file_dict, text))
+                warnings.extend(rule.checkrule(file_path, text))
 
             else:
-                errors.extend(rule.checkrule(file_dict, text))
+                errors.extend(rule.checkrule(file_path, text))
 
         for error in errors:
             logger.error(error.to_rich())

--- a/j2lint/linter/rule.py
+++ b/j2lint/linter/rule.py
@@ -92,13 +92,13 @@ class Rule(ABC):
     def checkline(self, filename: str, line: str, line_no: int) -> list[LinterError]:
         """This method is expected to be overriden by child classes"""
 
-    def checkrule(self, file: dict[str, Any], text: str) -> list[LinterError]:
+    def checkrule(self, filename: str, text: str) -> list[LinterError]:
         """
         Checks the string text against the current rule by calling
         either the checkline or checktext method depending on which one is implemented
 
         Args:
-            file (string): file path of the file to be checked
+            filename (string): file path of the file to be checked
             text (string): file text of the same file
 
         Returns:
@@ -108,7 +108,7 @@ class Rule(ABC):
 
         try:
             # First try with checktext
-            results = self.checktext(file["path"], text)
+            results = self.checktext(filename, text)
             errors.extend(results)
 
         except NotImplementedError:
@@ -121,7 +121,7 @@ class Rule(ABC):
                 if line.lstrip().startswith("#"):
                     continue
 
-                results = self.checkline(file["path"], line, line_no=index + 1)
+                results = self.checkline(filename, line, line_no=index + 1)
                 errors.extend(results)
                 # errors.append(LinterError(index + 1, line, file["path"], self))
         return errors

--- a/j2lint/linter/rule.py
+++ b/j2lint/linter/rule.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import json
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar, Literal
-from typing import Any, ClassVar
 
 from rich.text import Text
 

--- a/j2lint/linter/rule.py
+++ b/j2lint/linter/rule.py
@@ -13,8 +13,6 @@ from typing import Any, ClassVar, Literal
 from rich.text import Text
 
 from j2lint.linter.error import JinjaLinterError, LinterError
-from j2lint.logger import logger
-from j2lint.utils import is_valid_file_type
 
 
 class Rule(ABC):
@@ -106,12 +104,6 @@ class Rule(ABC):
             list: list of LinterError from issues in the given file
         """
         errors: list[LinterError] = []
-
-        if not is_valid_file_type(file["path"]):
-            logger.debug(
-                "Skipping file %s. Linter does not support linting this file type", file
-            )
-            return errors
 
         try:
             # First try with checktext

--- a/j2lint/linter/rule.py
+++ b/j2lint/linter/rule.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar
 
 from rich.text import Text
 
@@ -50,9 +51,9 @@ class Rule(ABC):
                     f"Class {cls} is missing required class attribute {attr}"
                 )
 
-        if cls.severity not in ["LOW", "MEDIUM", "HIGH"]:
+        if cls.severity not in [None, "LOW", "MEDIUM", "HIGH"]:
             raise JinjaLinterError(
-                f"Rule {cls.rule_id}: severity must be in ['LOW', 'MEDIUM', 'HIGH'], {cls.severity} was provided"
+                f"Rule {cls.rule_id}: severity must be in [None, 'LOW', 'MEDIUM', 'HIGH'], {cls.severity} was provided"
             )
 
     def __repr__(self) -> str:

--- a/j2lint/linter/runner.py
+++ b/j2lint/linter/runner.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 from j2lint.logger import logger
-from j2lint.utils import get_file_type
 
 from .collection import RulesCollection
 from .error import LinterError
@@ -21,16 +20,11 @@ class Runner:
     """
 
     def __init__(
-        self,
-        collection: RulesCollection,
-        file_name: str,
-        checked_files: list[str],
+        self, collection: RulesCollection, file_name: str, checked_files: list[str]
     ) -> None:
         self.collection = collection
-        self.files: set[tuple[str, str]] = set()
-        if (file_type := get_file_type(file_name)) is not None:
-            self.files.add((file_name, file_type))
-
+        # For now hardcoding this for first change - but this is useless so will simplify the structure
+        self.files: set[tuple[str, str]] = {(file_name, "jinja")}
         self.checked_files = checked_files
 
     def is_already_checked(self, file_path: str) -> bool:

--- a/j2lint/linter/runner.py
+++ b/j2lint/linter/runner.py
@@ -23,8 +23,7 @@ class Runner:
         self, collection: RulesCollection, file_name: str, checked_files: list[str]
     ) -> None:
         self.collection = collection
-        # For now hardcoding this for first change - but this is useless so will simplify the structure
-        self.files: set[tuple[str, str]] = {(file_name, "jinja")}
+        self.files: set[str] = {file_name}
         self.checked_files = checked_files
 
     def is_already_checked(self, file_path: str) -> bool:
@@ -48,32 +47,30 @@ class Runner:
                                from tuple to dict here
                                maybe simply init with the dict
         """
-        file_dicts: list[dict[str, str]] = []
+        files: list[str] = []
         for index, file in enumerate(self.files):
-            logger.debug("Running linting rules for %s", file)
-            file_path = file[0]
-            file_type = file[1]
-            file_dict = {"path": file_path, "type": file_type}
             # pylint: disable = fixme
             # FIXME - as of now it seems that both next tests
             #         will never occurs as self.files is always
             #         a single file.
             # Skip already checked files
-            if self.is_already_checked(file_path):
+            if self.is_already_checked(file):
                 continue
             # Skip duplicate files
-            if file_dict in file_dicts[:index]:
+            if file in files[:index]:
                 continue
-            file_dicts.append(file_dict)
+            files.append(file)
 
         errors: list[LinterError] = []
         warnings: list[LinterError] = []
         # pylint: disable = fixme
         # FIXME - if there are multiple files, errors and warnings are overwritten..
-        for file_dict in file_dicts:
-            errors, warnings = self.collection.run(file_dict)
+        #         fortunately there is only one file currently
+        for file in files:
+            logger.debug("Running linting rules for %s", file)
+            errors, warnings = self.collection.run(file)
 
         # Update list of checked files
-        self.checked_files.extend([file_dict["path"] for file_dict in file_dicts])
+        self.checked_files.extend(files)
 
         return errors, warnings

--- a/j2lint/utils.py
+++ b/j2lint/utils.py
@@ -58,38 +58,26 @@ def load_plugins(directory: str) -> list[Rule]:
     return result
 
 
-def is_valid_file_type(file_name: str) -> bool:
-    """Checks if the file is a valid Jinja file
+def is_valid_file_type(file_name: str, extensions: list[str]) -> bool:
+    """Checks if the file extension is in the list of accepted extensions
 
     Args:
         file_name (string): file path with extension
+        extensions (list): list of file extensions to look for
 
     Returns:
         boolean: True if file type is correct
     """
     extension = os.path.splitext(file_name)[1].lower()
-    return extension in [".jinja", ".jinja2", ".j2"]
+    return extension in extensions
 
 
-def get_file_type(file_name: str) -> str | None:
-    """Returns file type as Jinja or None
-
-    Args:
-        file_name (string): file path with extension
-
-    Returns:
-        string: jinja or None
-
-    TODO: this method and the previous one are redundant
-    """
-    return LANGUAGE_JINJA if is_valid_file_type(file_name) else None
-
-
-def get_files(file_or_dir_names: list[str]) -> list[str]:
+def get_files(file_or_dir_names: list[str], extensions: list[str]) -> list[str]:
     """Get files from a directory recursively
 
     Args:
         file_or_dir_names (list): list of directories and files
+        extensions (list): list of file extensions to look for
 
     Returns:
         list: list of file paths
@@ -106,9 +94,9 @@ def get_files(file_or_dir_names: list[str]) -> list[str]:
             for root, _, files in os.walk(file_or_dir):
                 for file in files:
                     file_path = os.path.join(root, file)
-                    if get_file_type(file_path) == LANGUAGE_JINJA:
+                    if is_valid_file_type(file_path, extensions):
                         file_paths.append(file_path)
-        elif get_file_type(file_or_dir) == LANGUAGE_JINJA:
+        elif is_valid_file_type(file_or_dir, extensions):
             file_paths.append(file_or_dir)
     logger.debug("Linting directory %s: files %s", file_or_dir_names, file_paths)
     return file_paths

--- a/j2lint/utils.py
+++ b/j2lint/utils.py
@@ -17,8 +17,6 @@ from j2lint.logger import logger
 if TYPE_CHECKING:
     from .linter.rule import Rule
 
-LANGUAGE_JINJA = "jinja"
-
 # Using Tuple from typing for 3.8 support
 # Statement type is a tuple
 # (line_without_delimiter, start_line, end_line, start_delimiter, end_delimiter)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,7 @@ commands = coverage erase
 
 [testenv:report]
 deps = coverage[toml]
-commands = coverage report
+commands = coverage report --rcfile=pyproject.toml
 # add the following to make the report fail under some percentage
 # commands = coverage report --fail-under=80
 depends = py310
@@ -139,6 +139,31 @@ log_cli = "True"
 [tool.coverage.run]
 source = ['j2lint']
 omit = ["j2lint/__main__.py"]
+
+[tool.coverage.report]
+# Regexes for lines to exclude from consideration
+exclude_lines = [
+	# Have to re-enable the standard pragma
+	"pragma: no cover",
+
+	# Don't complain about missing debug-only code:
+	"def __repr__",
+	"if self\\.debug",
+
+	# Don't complain if tests don't hit defensive assertion code:
+	"raise AssertionError",
+	"raise NotImplementedError",
+
+	# Don't complain if non-runnable code isn't run:
+	"if 0:",
+	"if __name__ == .__main__.:",
+
+	# Don't complain about abstract methods, they aren't run:
+	"@(abc\\.)?abstractmethod",
+
+	# Don't complain about TYPE_CHECKING blocks
+	"if TYPE_CHECKING:",
+]
 
 [tool.mypy]
 follow_imports = "skip"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,7 +43,7 @@ CONSOLE.size = ConsoleDimensions(width=80, height=74)
 @pytest.mark.parametrize(
     "argv, namespace_modifications",
     [
-        (pytest.param([], {}, id="default")),
+        (pytest.param([], {"extensions": [".j2", ".jinja", ".jinja2"]}, id="default")),
         pytest.param(
             ["--log", "--stdout", "-j", "-d", "-v", "--stdin", "--version"],
             {
@@ -54,6 +54,7 @@ CONSOLE.size = ConsoleDimensions(width=80, height=74)
                 "log": True,
                 "json": True,
                 "verbose": True,
+                "extensions": [".j2", ".jinja", ".jinja2"],
             },
             id="set all debug flags",
         ),

--- a/tests/test_linter/test_collection.py
+++ b/tests/test_linter/test_collection.py
@@ -50,16 +50,16 @@ class TestRulesCollection:
         assert collection.rules == fake_rules + fake_rules
 
     @pytest.mark.parametrize(
-        "file_dict, expected_results, verify_logs",
+        "file_path, expected_results, verify_logs",
         [
             pytest.param(
-                {"path": "dummy.j2"},
+                "dummy.j2",
                 ([], []),
                 False,
                 id="non existing file",
             ),
             pytest.param(
-                {"path": f"{TEST_DATA_DIR}/disable-rule-3.j2"},
+                f"{TEST_DATA_DIR}/disable-rule-3.j2",
                 (
                     [
                         ("T0", "test-rule-0"),
@@ -80,7 +80,7 @@ class TestRulesCollection:
         test_collection,
         make_rules,
         make_issue_from_rule,
-        file_dict,
+        file_path,
         expected_results,
         verify_logs,
     ):
@@ -98,7 +98,7 @@ class TestRulesCollection:
         rules[2].ignore = True
         test_collection.rules = rules
 
-        def checks_side_effect(self, file_dict, text):
+        def checks_side_effect(self, file_path, text):
             return make_issue_from_rule(self)
 
         with mock.patch(
@@ -106,7 +106,7 @@ class TestRulesCollection:
             side_effect=checks_side_effect,
             autospec=True,
         ):
-            errors, warnings = test_collection.run(file_dict)
+            errors, warnings = test_collection.run(file_path)
             error_tuples = [
                 (error.rule.rule_id, error.rule.short_description) for error in errors
             ]

--- a/tests/test_linter/test_rule.py
+++ b/tests/test_linter/test_rule.py
@@ -28,20 +28,6 @@ class TestRule:
         [
             pytest.param(
                 None,
-                None,
-                {"path": f"{TEST_DATA_DIR}/test.txt"},
-                [],
-                [
-                    (
-                        "root",
-                        logging.DEBUG,
-                        f"Skipping file {{'path': '{TEST_DATA_DIR}/test.txt'}}. Linter does not support linting this file type",
-                    )
-                ],
-                id="file is wrong type",
-            ),
-            pytest.param(
-                None,
                 0,
                 {"path": f"{TEST_DATA_DIR}/test.j2"},
                 [],

--- a/tests/test_linter/test_runner.py
+++ b/tests/test_linter/test_runner.py
@@ -8,8 +8,6 @@ from unittest import mock
 
 import pytest
 
-from j2lint.utils import get_file_type
-
 
 class TestRunner:
     @pytest.mark.parametrize(
@@ -49,7 +47,7 @@ class TestRunner:
 
         This test is "bad" for now.
         """
-        test_runner.files = {(file, get_file_type(file)) for file in runner_files}
+        test_runner.files = {(file, "jinja") for file in runner_files}
         # Fake return
         with mock.patch(
             "j2lint.linter.collection.RulesCollection.run"

--- a/tests/test_linter/test_runner.py
+++ b/tests/test_linter/test_runner.py
@@ -47,7 +47,7 @@ class TestRunner:
 
         This test is "bad" for now.
         """
-        test_runner.files = {(file, "jinja") for file in runner_files}
+        test_runner.files = runner_files
         # Fake return
         with mock.patch(
             "j2lint.linter.collection.RulesCollection.run"
@@ -59,7 +59,5 @@ class TestRunner:
             assert result == ([], [])
 
             for file in test_runner.files:
-                patched_collection_run.assert_any_call(
-                    {"path": file[0], "type": file[1]}
-                )
-                assert file[0] in test_runner.checked_files
+                patched_collection_run.assert_any_call(file)
+                assert file in test_runner.checked_files

--- a/tests/test_rules/test_rules.py
+++ b/tests/test_rules/test_rules.py
@@ -156,7 +156,7 @@ def test_rules(
     with open(filename, "r") as f:
         print(f.read())
     caplog.set_level(logging.INFO)
-    errors, warnings = collection.run({"path": filename, "type": "jinja"})
+    errors, warnings = collection.run(filename)
 
     errors_ids = [(error.rule.rule_id, error.line_number) for error in errors]
 


### PR DESCRIPTION
Fixes #66 

* Tested with ansible-avd - no change
* This PR adds the capability to chose different file extensions than the default one
* This PR also cleans a bit of the legacy syntax where we carried over some "JINJA_LANGUAGE" attached to files that were never used. This simplifies the codebase.
* Add some setting for coverage computation
* Update some dependencies
