### PR TITLE
CI: Update pyproject to new license format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ version = "v1.2.0"
 description = "Command-line utility that validates jinja2 syntax according to Arista's AVD style guide."
 readme = "README.md"
 authors = [{ name = "Arista Ansible Team", email = "ansible@arista.com" }]
-license = { file = "LICENSE" }
+license = "MIT"
+license-files = ["LICENSE"]
 classifiers = [
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",


### PR DESCRIPTION
# Description

cf https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license + deprecation warnings when running build