### PR TITLE
Fix: AttributeError: 'str' object has no attribute 'expanduser'

### DIFF
--- a/j2lint/linter/collection.py
+++ b/j2lint/linter/collection.py
@@ -188,6 +188,8 @@ class RulesCollection:
             A RulesColleciton object containing the rules from rules_dir except for the ignored ones.
         """
         result = cls()
+        if not hasattr(rules_dir, "expanduser"):
+            rules_dir = Path(rules_dir)
         result.rules = load_plugins(rules_dir.expanduser())
         for rule in result.rules:
             if rule.short_description in ignore_rules or rule.rule_id in ignore_rules:


### PR DESCRIPTION
This PR fixed issue with custom rules
```
(.venv) vv@zxpc~/Documents/cluster$ j2lint . -e $FILE_EXTENSIONS \
                               -i $IGNORE_RULES single-space-decorator jinja-statements-single-space \
                               -w $WARN_RULES -r linters/j2lint
```
```
Traceback (most recent call last):
  File "/home/vv/Documents/cluster/.venv/bin/j2lint", line 7, in <module>
    sys.exit(run())
             ^^^^^
  File "/home/vv/Documents/cluster/.venv/lib64/python3.11/site-packages/j2lint/cli.py", line 337, in run
    collection.extend(RulesCollection.create_from_directory(rules_dir, options.ignore, options.warn).rules)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/vv/Documents/cluster/.venv/lib64/python3.11/site-packages/j2lint/linter/collection.py", line 191, in create_from_directory
    result.rules = load_plugins(rules_dir.expanduser())
                                ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'expanduser'
```