### PR TITLE
Fix(cli): Pass correct type from CLI to RulesCollection

### DIFF
--- a/j2lint/cli.py
+++ b/j2lint/cli.py
@@ -119,6 +119,7 @@ def create_parser() -> argparse.ArgumentParser:
 
     return parser
 
+
 class J2LintArgsNamespace(argparse.Namespace):
     files: ClassVar[list[str]]
     list: ClassVar[bool]
@@ -349,7 +350,7 @@ def run(args: list[str] | None = None) -> int:
     # Collect the rules from the configuration
     collection = RulesCollection(verbose=options.verbose)
     for rules_dir in options.rules_dir:
-        collection.extend(RulesCollection.create_from_directory(rules_dir, options.ignore, options.warn).rules)
+        collection.extend(RulesCollection.create_from_directory(Path(rules_dir), options.ignore, options.warn).rules)
 
     # List lint rules
     if options.list:

--- a/j2lint/cli.py
+++ b/j2lint/cli.py
@@ -121,6 +121,13 @@ def create_parser() -> argparse.ArgumentParser:
 
 
 class J2LintArgsNamespace(argparse.Namespace):
+    """Typed representation of the argparse Namespace.
+
+    Allows pyright to detect type error in using CLI arguments.
+    """
+
+    # pylint: disable=too-few-public-methods
+
     files: ClassVar[list[str]]
     list: ClassVar[bool]
     rules_dir: ClassVar[list[str]]

--- a/j2lint/cli.py
+++ b/j2lint/cli.py
@@ -11,7 +11,7 @@ import logging
 import sys
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from rich.tree import Tree
 
@@ -118,6 +118,21 @@ def create_parser() -> argparse.ArgumentParser:
     )
 
     return parser
+
+class J2LintArgsNamespace(argparse.Namespace):
+    files: ClassVar[list[str]]
+    list: ClassVar[bool]
+    rules_dir: ClassVar[list[str]]
+    extensions: ClassVar[list[str]]
+    verbose: ClassVar[bool]
+    debug: ClassVar[bool]
+    json: ClassVar[bool]
+    stdin: ClassVar[bool]
+    log: ClassVar[bool]
+    version: ClassVar[str]
+    stdout: ClassVar[bool]
+    ignore: ClassVar[list[str]]
+    warn: ClassVar[list[str]]
 
 
 def sort_issues(issues: list[LinterError]) -> list[LinterError]:
@@ -305,7 +320,7 @@ def run(args: list[str] | None = None) -> int:
     # given the number of input parameters, it is acceptable to keep these many branches.
 
     parser = create_parser()
-    options = parser.parse_args(args if args is not None else sys.argv[1:])
+    options: J2LintArgsNamespace = parser.parse_args(args if args is not None else sys.argv[1:], namespace=J2LintArgsNamespace())
 
     # Enable logs
 


### PR DESCRIPTION
* This PR adds typing to ArgParse with minimum disruption to the codebase based on some answer here: https://stackoverflow.com/questions/42279063/python-typehints-for-argparse-namespace-objects
* Adding the types on top of pyright immediately shows that this is wrong - Yay
* It then fixes the reported issue. in the sceond commit

> [!WARNING]
> Needs to be merged after #191 


Fixes #190 