### PR TITLE
Fix(cli): Correct package description in help output

### DIFF
--- a/j2lint/__init__.py
+++ b/j2lint/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2021-2025 Arista Networks, Inc.
 # Use of this source code is governed by the MIT license
 # that can be found in the LICENSE file.
-"""__init__.py - A command-line utility that checks for best practices in Jinja2."""
+"""j2lint - A command-line utility that checks for best practices in Jinja2."""
 
 from rich.console import Console
 


### PR DESCRIPTION
When running `j2lint --help`, the output displays:

`__init__.py - A command-line utility that checks for best practices in Jinja2.`

The filename (`__init__.py`) should not appear in the help text. This PR updates the `__init__.py` file so the output now correctly shows:

`j2lint - A command-line utility that checks for best practices in Jinja2.`