### PR TITLE
CI: Add zizmor to the repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
       separator: "/"
     commit-message:
       prefix: "chore: "
+    cooldown:
+      default-days: 7
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -28,4 +30,6 @@ updates:
       - "CI"
     commit-message:
       prefix: "ci: "
+    cooldown:
+      default-days: 7
 

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,16 +13,18 @@ jobs:
       contents: read
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Download coverage from unit tests
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pytest-coverage
 
       - name: Upload results to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           use_oidc: true
           fail_ci_if_error: true

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -6,14 +6,19 @@ name: Code Testing
       - devel
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Run pylint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
       - name: Install dependencies
@@ -24,9 +29,11 @@ jobs:
     name: Run pyright
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
       - name: Install dependencies
@@ -40,9 +47,11 @@ jobs:
       matrix:
         python: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
@@ -53,7 +62,7 @@ jobs:
         # Coverage only runs as part of 3.11.
         if: |
           matrix.python == '3.11'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pytest-coverage
           path: ${{ github.workspace }}/coverage.xml
@@ -61,4 +70,7 @@ jobs:
     name: Upload coverage to codecov
     needs: [tox]
     if: github.repository == 'aristanetworks/j2lint'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/codecov.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,13 @@ jobs:
       name: production
       url: https://pypi.org/p/j2lint
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -25,7 +28,7 @@ jobs:
         run: |
           python -m build
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
 
   # TODO: in a separate PR
   # docker:
@@ -45,7 +48,7 @@ jobs:
 
   #     - name: Docker meta for TAG
   #       id: meta
-  #       uses: docker/metadata-action@v5
+  #       uses: docker/metadata-action@v6
   #       with:
   #         images: ghcr.io/${{ github.repository }}
   #         tags: |
@@ -53,14 +56,14 @@ jobs:
   #           type=raw,value=latest
 
   #     - name: Login to GitHub Container Registry
-  #       uses: docker/login-action@v3
+  #       uses: docker/login-action@v4
   #       with:
   #         registry: ghcr.io
   #         username: ${{ github.actor }}
   #         password: ${{ secrets.GITHUB_TOKEN }}
 
   #     - name: Build and push
-  #       uses: docker/build-push-action@v6
+  #       uses: docker/build-push-action@v7
   #       with:
   #         context: .
   #         file: Dockerfile

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,31 @@
+---
+name: zizmor
+
+"on":
+  pull_request:
+    paths:
+      - ".github/**"
+  push:
+    branches:
+      - devel
+    paths:
+      - ".github/**"
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: Audit GitHub Actions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install zizmor
+        run: cargo install --locked zizmor
+
+      - name: Run zizmor
+        run: zizmor .github


### PR DESCRIPTION
- Pin GitHub Actions dependencies to commit SHAs while keeping version comments for readability.
- Disable checkout credential persistence with persist-credentials: false where jobs only need read access.
- Add explicit minimal workflow permissions for test, coverage, release, and zizmor jobs.
- Add Dependabot cooldowns for pip and GitHub Actions updates.
- Add a zizmor workflow for pull requests touching .github and pushes to devel.
- Install zizmor with cargo instead of using the unapproved zizmor GitHub Action.
- Run zizmor against the full .github directory so workflows and Dependabot config are audited.
- Refresh commented Docker workflow action versions to current major releases.