### PR TITLE
Fix(j2lint): Reset indentation parser state between files

### DIFF
--- a/j2lint/linter/indenter/node.py
+++ b/j2lint/linter/indenter/node.py
@@ -21,7 +21,6 @@ DEFAULT_WHITESPACES = 1
 JINJA_START_DELIMITERS = ["{%-", "{%+"]
 
 jinja_node_stack: list[Node] = []
-jinja_delimiter_stack: list[str] = []
 
 NodeIndentationError = tuple[int, str, str]
 

--- a/j2lint/rules/jinja_template_indentation_rule.py
+++ b/j2lint/rules/jinja_template_indentation_rule.py
@@ -45,6 +45,7 @@ class JinjaTemplateIndentationRule(Rule):
         # indentation level for each statement
         root = Node()
         node_errors: list[NodeIndentationError] = []
+        jinja_node_stack.clear()
         try:
             root.check_indentation(node_errors, lines, 0)
 

--- a/j2lint/rules/jinja_template_indentation_rule.py
+++ b/j2lint/rules/jinja_template_indentation_rule.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from j2lint.linter.error import JinjaLinterError, LinterError
-from j2lint.linter.indenter.node import Node, NodeIndentationError
+from j2lint.linter.indenter.node import Node, NodeIndentationError, jinja_node_stack
 from j2lint.linter.rule import Rule
 from j2lint.logger import logger
 from j2lint.utils import get_jinja_statements
@@ -55,6 +55,10 @@ class JinjaTemplateIndentationRule(Rule):
                 filename,
                 str(exc),
             )
+        finally:
+            # A parse failure can leave nodes from this file on the module-level
+            # stack, which would corrupt the check of the next file.
+            jinja_node_stack.clear()
 
         return [LinterError(line_no, section, filename, self, message) for line_no, section, message in node_errors]
 

--- a/tests/test_linter/test_indenter/test_node.py
+++ b/tests/test_linter/test_indenter/test_node.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import pytest
 
-from j2lint.linter.indenter.node import Node
+from j2lint.linter.indenter.node import Node, NodeIndentationError, jinja_node_stack
 
 
 class TestNode:
@@ -36,3 +36,20 @@ class TestNode:
             "{% if switch.platform_settings.tcam_profile is arista.avd.defined %}",
             "test",
         )
+
+    def test_check_indentation_returns_to_begin_tag_after_middle_tag(self) -> None:
+        """Test that a middle tag returns parsing to the matching begin tag."""
+        lines = [
+            (" if enabled ", 1, 1, "{%", "%}"),
+            (" else ", 2, 2, "{%", "%}"),
+            (" endif ", 3, 3, "{%", "%}"),
+        ]
+        result: list[NodeIndentationError] = []
+        jinja_node_stack.clear()
+
+        try:
+            assert Node().check_indentation(result, lines, 0) is None
+            assert not result
+            assert not jinja_node_stack
+        finally:
+            jinja_node_stack.clear()

--- a/tests/test_rules/test_rules.py
+++ b/tests/test_rules/test_rules.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from j2lint.rules.jinja_template_indentation_rule import JinjaTemplateIndentationRule
 from j2lint.rules.jinja_template_single_statement_rule import JinjaTemplateSingleStatementRule
 
 if TYPE_CHECKING:
@@ -123,7 +124,7 @@ PARAMS = [
     ),
     pytest.param(
         f"{TEST_DATA_DIR}/jinja_statement_delimiter_rule.j2",
-        [("S6", 6), ("S6", 8), ("S6", 10)],
+        [("S6", 6), ("S3", 7), ("S6", 8), ("S3", 9), ("S6", 10)],
         [],
         [],
     ),
@@ -224,3 +225,15 @@ def test_jinja_template_single_statement_rule_ignores_empty_statements() -> None
     rule = JinjaTemplateSingleStatementRule()
 
     assert not rule.checkline("dummy.j2", "{%%} {% if foo %}", 1)
+
+
+def test_jinja_template_indentation_rule_resets_state_between_files() -> None:
+    """A file that fails to parse must not leak indentation state into the next file."""
+    rule = JinjaTemplateIndentationRule()
+
+    contaminator = "{% if enabled %}{% for item in items %}\n{{ item }}{% endfor %}{% endif %}\n"
+    victim = "text{% if enabled %}\n    value\n{% endif %}\n"
+
+    assert not rule.checktext("victim.j2", victim)
+    rule.checktext("contaminator.j2", contaminator)
+    assert not rule.checktext("victim.j2", victim)

--- a/tests/test_rules/test_rules.py
+++ b/tests/test_rules/test_rules.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from j2lint.linter.indenter.node import jinja_node_stack
 from j2lint.rules.jinja_template_indentation_rule import JinjaTemplateIndentationRule
 from j2lint.rules.jinja_template_single_statement_rule import JinjaTemplateSingleStatementRule
 
@@ -227,13 +228,16 @@ def test_jinja_template_single_statement_rule_ignores_empty_statements() -> None
     assert not rule.checkline("dummy.j2", "{%%} {% if foo %}", 1)
 
 
-def test_jinja_template_indentation_rule_resets_state_between_files() -> None:
+def test_jinja_template_indentation_rule_resets_state_between_files(caplog: pytest.LogCaptureFixture) -> None:
     """A file that fails to parse must not leak indentation state into the next file."""
+    caplog.set_level(logging.ERROR)
     rule = JinjaTemplateIndentationRule()
 
     contaminator = "{% if enabled %}{% for item in items %}\n{{ item }}{% endfor %}{% endif %}\n"
-    victim = "text{% if enabled %}\n    value\n{% endif %}\n"
+    victim = "{% if enabled %}\n    value\n{% endif %}\n"
 
     assert not rule.checktext("victim.j2", victim)
-    rule.checktext("contaminator.j2", contaminator)
+    assert not rule.checktext("contaminator.j2", contaminator)
+    assert any("Indentation check failed for file contaminator.j2" in record.message for record in caplog.records)
+    assert not jinja_node_stack
     assert not rule.checktext("victim.j2", victim)


### PR DESCRIPTION
Fixes #292.

`jinja_node_stack` in `j2lint/linter/indenter/node.py` is module-level, and `JinjaTemplateIndentationRule.checktext` swallows `JinjaLinterError`/`IndexError` without clearing it, so a file that fails to parse leaves its nodes on the stack and later files get checked against them. This makes lint results depend on file order (issue has a two-file reproducer). The fix clears the stack in a `finally` so every file starts fresh.

Turns out the existing `jinja_statement_delimiter_rule.j2` expectations were relying on this: that param fails on devel when run alone (`pytest -k delimiter`), and passed in the full suite only because the indentation-rule data file leaked state first. Updated them to match what `j2lint` reports for that file on its own, which is also what the CLI prints today on devel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed indentation validation so that failed template parsing/indentation checks no longer leave residual state that could impact subsequent template checks.
  * Improved reliability when validating indentation across multiple template runs.
* **Tests**
  * Added a regression test to ensure indentation state is fully reset between separate template checks.
  * Updated expected rule-violation outputs for a delimiter-related parametrized scenario.
  * Added a unit test to confirm indentation checking returns to the correct state after nested tag transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->