### PR TITLE
CI: Unify release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,10 +34,20 @@ jobs:
       - name: Set target version
         id: target_version
         env:
+          EVENT_NAME: ${{ github.event_name }}
           INPUT_VALUE: ${{ inputs.TESTPYPI_VERSION }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |-
           CURRENT_VERSION=$(bumpver show --environ | grep '^CURRENT_VERSION=' | cut -f "2" -d "=")
-          TARGET_VERSION="${INPUT_VALUE:-$CURRENT_VERSION}"
+          if [ "$EVENT_NAME" = "release" ]; then
+            if [ "$RELEASE_TAG" != "$CURRENT_VERSION" ]; then
+              echo "::error::Release tag '$RELEASE_TAG' does not match package version '$CURRENT_VERSION'"
+              exit 1
+            fi
+            TARGET_VERSION="$CURRENT_VERSION"
+          else
+            TARGET_VERSION="${INPUT_VALUE:-$CURRENT_VERSION}"
+          fi
           echo "TARGET_VERSION=$TARGET_VERSION" >> "$GITHUB_OUTPUT"
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
 
@@ -94,7 +104,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
 
   test-j2lint-from-test-pypi:
     name: Test from TestPyPI on Python ${{ matrix.python }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,150 @@
 ---
 name: "Tag & Release management"
-on:
+"on":
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      TESTPYPI_VERSION:
+        description: "Version string to use for manual push to test PyPI"
+        required: true
+        type: string
+
+permissions:
+  contents: read
 
 jobs:
-  pypi:
-    name: Publish Python 🐍 distribution 📦 to PyPI
+  target_version:
+    name: Set target version
     runs-on: ubuntu-latest
+    outputs:
+      current_version: ${{ steps.target_version.outputs.CURRENT_VERSION }}
+      target_version: ${{ steps.target_version.outputs.TARGET_VERSION }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Install bumpver
+        run: |-
+          python -m pip install --group bumpver
+      - name: Set target version
+        id: target_version
+        env:
+          INPUT_VALUE: ${{ inputs.TESTPYPI_VERSION }}
+        run: |-
+          CURRENT_VERSION=$(bumpver show --environ | grep '^CURRENT_VERSION=' | cut -f "2" -d "=")
+          TARGET_VERSION="${INPUT_VALUE:-$CURRENT_VERSION}"
+          echo "TARGET_VERSION=$TARGET_VERSION" >> "$GITHUB_OUTPUT"
+          echo "CURRENT_VERSION=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+
+  build-j2lint-dist:
+    name: Build j2lint distribution ${{ needs.target_version.outputs.target_version }}
+    needs: [target_version]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Install Python requirements
+        run: |-
+          python -m pip install --group bumpver build setuptools
+      - name: Update version
+        if: needs.target_version.outputs.target_version != needs.target_version.outputs.current_version
+        env:
+          TARGET_VERSION: ${{ needs.target_version.outputs.target_version }}
+        run: |-
+          git config --global user.email "ansible@arista.com"
+          git config --global user.name "j2lint CI BOT"
+          bumpver update --set-version "$TARGET_VERSION"
+      - name: Build
+        run: |-
+          python -m build
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: j2lint-dist
+          path: dist/
+
+  publish-j2lint-testpypi:
+    name: Publish j2lint Python distribution to TestPyPI
+    needs: [build-j2lint-dist]
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'release'
+      || github.event_name == 'workflow_dispatch'
+    environment:
+      name: test
+      url: https://test.pypi.org/p/j2lint
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download j2lint dist
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: j2lint-dist
+          path: dist/
+      - name: Publish distribution to TestPyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+  test-j2lint-from-test-pypi:
+    name: Test from TestPyPI on Python ${{ matrix.python }}
+    needs: [target_version, publish-j2lint-testpypi]
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'release'
+      || github.event_name == 'workflow_dispatch'
+    strategy:
+      matrix:
+        python: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - name: Checkout only the tests
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          sparse-checkout: |-
+            tests
+            pyproject.toml
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Update expected test version
+        if: needs.target_version.outputs.target_version != needs.target_version.outputs.current_version
+        env:
+          CURRENT_VERSION: ${{ needs.target_version.outputs.current_version }}
+          TARGET_VERSION: ${{ needs.target_version.outputs.target_version }}
+        run: |-
+          python - <<'PY'
+          import os
+          from pathlib import Path
+
+          test_cli = Path("tests/test_cli.py")
+          text = test_cli.read_text()
+          test_cli.write_text(text.replace(os.environ["CURRENT_VERSION"], os.environ["TARGET_VERSION"]))
+          PY
+      - name: Install j2lint from TestPyPI
+        env:
+          TARGET_VERSION: ${{ needs.target_version.outputs.target_version }}
+        run: |-
+          pip install -i https://test.pypi.org/simple/ "j2lint==$TARGET_VERSION" --group test --extra-index-url https://pypi.org/simple
+      - name: Run tests
+        run: |-
+          pytest tests
+
+  publish-j2lint-pypi:
+    name: Publish j2lint Python distribution to PyPI
+    needs: [test-j2lint-from-test-pypi]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
     environment:
       name: production
       url: https://pypi.org/p/j2lint
@@ -16,58 +152,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Download j2lint dist
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          persist-credentials: false
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel build
-      - name: Build package
-        run: |
-          python -m build
-      - name: Publish distribution 📦 to PyPI
+          name: j2lint-dist
+          path: dist/
+      - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-
-  # TODO: in a separate PR
-  # docker:
-  #   name: Docker Image Build
-  #   runs-on: ubuntu-latest
-  #   needs: [pypi]
-  #   strategy:
-  #     matrix:
-  #       platform:
-  #         - linux/amd64
-  #         - linux/arm64
-  #         - linux/arm/v7
-  #         - linux/arm/v8
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v6
-
-  #     - name: Docker meta for TAG
-  #       id: meta
-  #       uses: docker/metadata-action@v6
-  #       with:
-  #         images: ghcr.io/${{ github.repository }}
-  #         tags: |
-  #           type=semver,pattern={{version}}
-  #           type=raw,value=latest
-
-  #     - name: Login to GitHub Container Registry
-  #       uses: docker/login-action@v4
-  #       with:
-  #         registry: ghcr.io
-  #         username: ${{ github.actor }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
-
-  #     - name: Build and push
-  #       uses: docker/build-push-action@v7
-  #       with:
-  #         context: .
-  #         file: Dockerfile
-  #         push: true
-  #         platforms: linux/amd64
-  #         tags: ${{ steps.meta.outputs.tags }}
-  #         labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tests/tmp/**
 .vscode
 coverage.xml
 uv.lock
+.envrc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,10 +36,13 @@ requires-python = ">=3.10"
 ci = [
   "tox>=4.56.4,<5.0.0",
 ]
-dev = [
-  "pre-commit>=4.6.0",
+bumpver = [
   "bumpver==2026.1132",
+]
+dev = [
   { include-group = "ci" },
+  { include-group = "bumpver" },
+  "pre-commit>=4.6.0",
 ]
 test = [
   "pytest>=9.1.1",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * Introduced staged publishing: build once, publish to TestPyPI, run tests, then publish to production PyPI.
  * Added automated Python compatibility testing across Python 3.10–3.13.
  * Added tag/version validation for published releases and support for manual workflow runs with optional version selection.
* **Chores**
  * Excluded local `.envrc` files from version control.
  * Organized development tooling dependencies by moving version-bumping tooling into a dedicated group.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->