### PR TITLE
Doc: Update to prepare release 1.3.0

### DIFF
--- a/.github/release_process.md
+++ b/.github/release_process.md
@@ -69,38 +69,25 @@ Use a PEP 440 version without the leading `v` for `TESTPYPI_VERSION`, for exampl
 
 ## Release version `x.x.x`
 
-TODO - make this a workflow
-
 `x.x.x` is the version to be released
 
-This is to be executed at the top of the repo
+The primary release path is the `Tag & Release management` workflow.
 
-1. Checkout the latest version of devel with the correct tag for the release
-2. [Optional] Clean dist if required
-3. Build the package locally
+1. Checkout the latest `devel` branch.
+2. Bump the version and open a pull request.
    ```
-   python -m build
+   bumpver update --minor
    ```
-4. Check the package with `twine` (replace with your version)
-    ```
-    twine check dist/j2lint-x.x.x-py3-none-any.whl
-    ```
-5. Upload the package to test.pypi
-    ```
-    twine upload -r testpypi dist/j2lint-x.x.x.*
-    ```
-6. Verify the package by installing it in a local venv and checking it installs
-   and run correctly (run the tests)
-   ```
-   # In a brand new venv
-   pip install -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple  --no-cache j2lint
-   ```
-7. Upload the package to pypi
-    ```
-    twine upload dist/j2lint-x.x.x.*
-    ```
-8. Like 5 but for normal pypi
-   ```
-   # In a brand new venv
-   pip install j2lint
-   ```
+3. Merge the version bump after CI passes.
+4. Create a GitHub release with the tag `vx.x.x`, matching the package version.
+5. The release workflow verifies the release tag matches the package version.
+6. The release workflow builds the package and publishes it to TestPyPI.
+7. The release workflow installs the TestPyPI package and runs the tests on Python 3.10, 3.11, 3.12, 3.13, and 3.14.
+8. After the TestPyPI validation passes, the release workflow publishes the same distribution to PyPI.
+
+Optional local package validation before creating the release:
+
+```
+python -m build
+twine check dist/j2lint-x.x.x-py3-none-any.whl
+```

--- a/.github/release_process.md
+++ b/.github/release_process.md
@@ -75,7 +75,7 @@ The primary release path is the `Tag & Release management` workflow.
 
 1. Checkout the latest `devel` branch.
 2. Bump the version and open a pull request.
-   ```
+   ```bash
    bumpver update --minor
    ```
 3. Merge the version bump after CI passes.
@@ -87,7 +87,7 @@ The primary release path is the `Tag & Release management` workflow.
 
 Optional local package validation before creating the release:
 
-```
+```bash
 python -m build
 twine check dist/j2lint-x.x.x-py3-none-any.whl
 ```

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tests/tmp/**
 coverage.xml
 uv.lock
 .envrc
+.worktrees

--- a/README.md
+++ b/README.md
@@ -127,7 +127,13 @@ j2lint <path-to-directory-of-templates> --json
 
 ### Ignoring rules
 
-1. The --ignore option can have one or more of these values: syntax-error, single-space-decorator, filter-enclosed-by-spaces, jinja-statement-single-space, jinja-statements-indentation, no-tabs, single-statement-per-line, jinja-delimiter, jinja-variable-lower-case, jinja-variable-format.
+1. The `--ignore` option can have one or more rule IDs or short descriptions:
+   `S0`, `S1`, `S2`, `S3`, `S4`, `S5`, `S6`, `S7`, `V1`, `V2`,
+   `jinja-syntax-error`, `single-space-decorator`,
+   `operator-enclosed-by-spaces`, `jinja-statements-single-space`,
+   `jinja-statements-indentation`, `jinja-statements-no-tabs`,
+   `single-statement-per-line`, `jinja-statements-delimiter`,
+   `jinja-variable-lower-case`, `jinja-variable-format`.
 
 2. If multiple rules are to be ignored, use the --ignore option along with rule descriptions separated by space.
 
@@ -136,7 +142,6 @@ j2lint <path-to-directory-of-templates> --json
     ```
 
 > **Note**
-> This runs the custom linting rules in addition to the default linting rules.
 > When using the `-i/--ignore` or `-w/--warn` options, the arguments MUST either:
 >
 > - Be entered at the end of the CLI as in the example above
@@ -153,13 +158,13 @@ j2lint <path-to-directory-of-templates> --json
     {# j2lint: disable=S6 #}
 
     # OR
-    {# j2lint: disable=jinja-delimiter #}
+    {# j2lint: disable=jinja-statements-delimiter #}
     ```
 
 4. Disabling multiple rules
 
     ```jinja2
-    {# j2lint: disable=jinja-delimiter j2lint: disable=S1 #}
+    {# j2lint: disable=jinja-statements-delimiter j2lint: disable=S1 #}
     ```
 
 ### Adding custom rules
@@ -170,10 +175,10 @@ j2lint <path-to-directory-of-templates> --json
     - File name: `jinja_operator_has_spaces_rule.py`
     - Class name: `JinjaOperatorHasSpacesRule`
 
-3. Run the jinja2 linter using --rules-dir option
+3. Run the jinja2 linter using the `-r` or `--rules_dir` option
 
     ```bash
-    j2lint <path-to-directory-of-templates> --rules-dir <custom-rules-directory>
+    j2lint <path-to-directory-of-templates> -r <custom-rules-directory>
     ```
 
 > **Note**

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,6 +85,24 @@ def test_create_parser(default_namespace: Namespace, argv: list[str], namespace_
 
 
 @pytest.mark.parametrize(
+    "argv",
+    [
+        pytest.param(["-r", "custom_rules", "tests/data/test.j2"], id="short rules dir"),
+        pytest.param(["--rules_dir", "custom_rules", "tests/data/test.j2"], id="long rules dir"),
+        pytest.param(["--ignore", "jinja-statements-delimiter", "--", "tests/data/test.j2"], id="ignore by short description"),
+        pytest.param(["--ignore", "S6", "--", "tests/data/test.j2"], id="ignore by rule id"),
+        pytest.param(["--warn", "jinja-statements-delimiter", "--", "tests/data/test.j2"], id="warn by short description"),
+        pytest.param(["--warn", "S6", "--", "tests/data/test.j2"], id="warn by rule id"),
+    ],
+)
+def test_create_parser_documented_options(argv: list[str]) -> None:
+    """Test documented CLI option spellings and rule names."""
+    parser = create_parser()
+
+    parser.parse_args(argv)
+
+
+@pytest.mark.parametrize(
     ("number_issues", "issues_modifications", "expected_sorted_issues_ids"),
     [
         (0, {}, []),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,7 @@ from j2lint.cli import (
     run,
     sort_issues,
 )
+from j2lint.linter.collection import DEFAULT_RULE_DIR
 
 from .utils import (
     NO_ERROR_NO_WARNING_JSON,
@@ -85,21 +86,60 @@ def test_create_parser(default_namespace: Namespace, argv: list[str], namespace_
 
 
 @pytest.mark.parametrize(
-    "argv",
+    ("argv", "expected_rules_dir", "expected_ignore", "expected_warn", "expected_files"),
     [
-        pytest.param(["-r", "custom_rules", "tests/data/test.j2"], id="short rules dir"),
-        pytest.param(["--rules_dir", "custom_rules", "tests/data/test.j2"], id="long rules dir"),
-        pytest.param(["--ignore", "jinja-statements-delimiter", "--", "tests/data/test.j2"], id="ignore by short description"),
-        pytest.param(["--ignore", "S6", "--", "tests/data/test.j2"], id="ignore by rule id"),
-        pytest.param(["--warn", "jinja-statements-delimiter", "--", "tests/data/test.j2"], id="warn by short description"),
-        pytest.param(["--warn", "S6", "--", "tests/data/test.j2"], id="warn by rule id"),
+        pytest.param(
+            ["-r", "custom_rules", "tests/data/test.j2"],
+            [DEFAULT_RULE_DIR, "custom_rules"],
+            [],
+            [],
+            ["tests/data/test.j2"],
+            id="short rules dir",
+        ),
+        pytest.param(
+            ["--rules_dir", "custom_rules", "tests/data/test.j2"],
+            [DEFAULT_RULE_DIR, "custom_rules"],
+            [],
+            [],
+            ["tests/data/test.j2"],
+            id="long rules dir",
+        ),
+        pytest.param(
+            ["--ignore", "jinja-statements-delimiter", "--", "tests/data/test.j2"],
+            [DEFAULT_RULE_DIR],
+            ["jinja-statements-delimiter"],
+            [],
+            ["tests/data/test.j2"],
+            id="ignore by short description",
+        ),
+        pytest.param(["--ignore", "S6", "--", "tests/data/test.j2"], [DEFAULT_RULE_DIR], ["S6"], [], ["tests/data/test.j2"], id="ignore by rule id"),
+        pytest.param(
+            ["--warn", "jinja-statements-delimiter", "--", "tests/data/test.j2"],
+            [DEFAULT_RULE_DIR],
+            [],
+            ["jinja-statements-delimiter"],
+            ["tests/data/test.j2"],
+            id="warn by short description",
+        ),
+        pytest.param(["--warn", "S6", "--", "tests/data/test.j2"], [DEFAULT_RULE_DIR], [], ["S6"], ["tests/data/test.j2"], id="warn by rule id"),
     ],
 )
-def test_create_parser_documented_options(argv: list[str]) -> None:
+def test_create_parser_documented_options(
+    argv: list[str],
+    expected_rules_dir: list[Path | str],
+    expected_ignore: list[str],
+    expected_warn: list[str],
+    expected_files: list[str],
+) -> None:
     """Test documented CLI option spellings and rule names."""
     parser = create_parser()
 
-    parser.parse_args(argv)
+    options = parser.parse_args(argv)
+
+    assert options.rules_dir == expected_rules_dir
+    assert options.ignore == expected_ignore
+    assert options.warn == expected_warn
+    assert options.files == expected_files
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release instructions to use the GitHub “Tag & Release management” workflow, including optional local build and validation.
  * Refreshed README CLI docs for rule identifiers, ignoring/warning selectors, custom rule directory flags (`-r/--rules_dir`), and updated Jinja disable examples.

* **Tests**
  * Added CLI tests to verify documented `create_parser()` option spellings and correct parsing for `--ignore/--warn` and `-r/--rules_dir`.

* **Chores**
  * Updated `.gitignore` to ignore `.worktrees`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->