### PR TITLE
CI: Make renovate handle pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,6 @@
 ---
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-ci:
-  autoupdate_commit_msg: "CI: pre-commit autoupdate"
-  skip: [pyright]
 files: ^(j2lint|tests|\.github)/
 
 repos:
@@ -59,6 +56,7 @@ repos:
         name: Check for Linting error on Python files
         description: This hook runs pylint.
         types: [python]
+        language: python
         args:
           - -rn # Only display messages
           - -sn # Don't display the score
@@ -66,10 +64,10 @@ repos:
           # Suppress duplicate code for modules header
           - -d duplicate-code
         additional_dependencies:
-          - jinja2
-          - rich
-          - pytest
-          - typing_extensions
+          - jinja2==3.1.6
+          - rich==15.0.0
+          - pytest==9.1.1
+          - typing_extensions==4.15.0
 
   - repo: https://github.com/RobertCraigie/pyright-python
     rev: 392b6ba8e54be6d603e02e9f8d601d27b7a48d12  # frozen: v1.1.411
@@ -77,11 +75,12 @@ repos:
       - id: pyright
         name: PyRight static type checker
         types: [python]
+        language: python
         additional_dependencies:
-          - jinja2
-          - rich
-          - pytest
-          - typing_extensions
+          - jinja2==3.1.6
+          - rich==15.0.0
+          - pytest==9.1.1
+          - typing_extensions==4.15.0
 
   - repo: https://github.com/codespell-project/codespell
     rev: 57b21406f092110c18776e39b0bda50d37c945c8  # frozen: v2.4.3

--- a/renovate.jsonc
+++ b/renovate.jsonc
@@ -12,12 +12,10 @@
   "dependencyDashboard": true,
 
   // Match j2lint's dependency surfaces intentionally.
-  // pre-commit is included explicitly for Python additional_dependencies only; hook rev
-  // updates stay with pre-commit.ci.
+  // pre-commit is included explicitly for hook revisions and Python additional_dependencies.
   "enabledManagers": ["pep621", "github-actions", "pre-commit"],
 
-  // Renovate's pre-commit manager is disabled by default. Keep it enabled only
-  // because we disable hook repository rev updates below.
+  // The pre-commit manager is disabled by default, so enable it explicitly.
   "pre-commit": {
     "enabled": true
   },
@@ -79,13 +77,13 @@
       "schedule": ["before 5am on monday"]
     },
     {
-      "description": "Let pre-commit.ci keep handling hook rev autoupdates.",
+      "description": "Let Renovate handle pre-commit hook revision updates.",
       "matchManagers": ["pre-commit"],
       "matchDepTypes": ["repository"],
-      "enabled": false
+      "enabled": true
     },
     {
-      "description": "pre-commit Python additional_dependencies only; hook rev updates stay with pre-commit.ci.",
+      "description": "Keep pre-commit Python additional_dependencies updated.",
       "matchManagers": ["pre-commit"],
       "matchDepTypes": ["pre-commit-python"],
       "labels": ["CI"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated maintenance settings to manage pre-commit hook and Python tool updates more consistently.
  * Standardized development tooling environments with explicit Python configuration and pinned supporting packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->